### PR TITLE
Adds a UI chat example and block works correctly

### DIFF
--- a/ai/ui.yaml
+++ b/ai/ui.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ai-ui
+  labels:
+    app: ai-ui
+spec:
+  containers:
+    - name: ollama-ui
+      image: jakobhoeg/nextjs-ollama-ui:latest
+      ports:
+        - containerPort: 8000
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: OLLAMA_URL
+          value: "http://ollama1.ollama:11434"
+        - name: TOKEN
+          value: ""
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 1Gi
+        limits:
+          cpu: 2000m
+          memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ai-ui
+  name: ai-ui
+spec:
+  type: NodePort
+  ports:
+    - port: 3000
+      nodePort: 30009
+  selector:
+    app: ui

--- a/gateway/pkg/connection/connection.go
+++ b/gateway/pkg/connection/connection.go
@@ -77,7 +77,7 @@ func (c *Config) StartListeners(listener net.Listener, internal bool) {
 						go c.internalkTLSProxy(conn)
 					} else {
 						if c.AI {
-							go c.internalProxy(conn, gateway.Http_gateway)
+							go c.directConnect(conn, gateway.Http_gateway)
 						} else {
 							go c.internalProxy(conn, gateway.Copy_gateway)
 						}
@@ -91,7 +91,34 @@ func (c *Config) StartListeners(listener net.Listener, internal bool) {
 	}
 }
 
-// HTTP proxy request handler
+func (c *Config) directConnect(conn net.Conn, gatewayFunc func(net.Conn, net.Conn, *gateway.AITransaction) error) {
+	defer conn.Close()
+	// Get original destination address
+	destAddr, destPort, err := c.findTargetFromConnection(conn)
+	if err != nil {
+		return
+	}
+	targetDestination := fmt.Sprintf("%s:%d", destAddr, destPort) //nolint
+
+	// Check that the original destination address is reachable from the proxy
+	targetConn, err := net.DialTimeout("tcp", targetDestination, 5*time.Second)
+	if err != nil {
+		slog.Error("direct connect", "target", targetDestination, "err", err)
+
+		return
+	}
+	slog.Info("direct connect", "target", targetDestination)
+
+	// gatewayFunc(input from the application, A destination, the configuration)
+
+
+	err = gatewayFunc(conn, targetConn, c.AITransaction)
+	if err != nil {
+		slog.Error("data write", "err", err)
+	}
+}
+
+// Create internal Proxy
 func (c *Config) internalProxy(conn net.Conn, gatewayFunc func(net.Conn, net.Conn, *gateway.AITransaction) error) {
 	defer conn.Close()
 	// Get original destination address

--- a/gateway/pkg/gateway/http_gateway.go
+++ b/gateway/pkg/gateway/http_gateway.go
@@ -17,6 +17,7 @@ import (
 )
 
 func Http_gateway(ingress, egress net.Conn, c *AITransaction) error {
+	// gatewayFunc(input from the application, A destination, the configuration)
 
 	go func() {
 		for {
@@ -27,14 +28,24 @@ func Http_gateway(ingress, egress net.Conn, c *AITransaction) error {
 					return
 				}
 				slog.Error("reading request", "err", err)
-				return
+				continue
+				//return
 			}
 			//  fmt.Println(req)
 			body, err := io.ReadAll(req.Body)
-
+			if err != nil {
+				slog.Error("data read", "err", err)
+				if err == io.EOF {
+					return
+				}
+				return
+			}
 			chat := openai.ChatCompletionNewParams{}
 
 			err = json.Unmarshal(body, &chat)
+			if err != nil {
+				slog.Error("data parsing (AI)", "err", err)
+			}
 			request := c.GetRequest()
 			if request != nil {
 				if c.Request.Debug {
@@ -54,7 +65,12 @@ func Http_gateway(ingress, egress net.Conn, c *AITransaction) error {
 						slog.Error("generating locking request", "err", err)
 					}
 					r := http.Response{
+						Status:     "200 OK",
 						StatusCode: 200,
+						Proto:      "HTTP/1.1",
+						ProtoMajor: 1,
+						ProtoMinor: 1,
+						Request:    req,
 						Header:     make(http.Header),
 					}
 					r.Header.Add("Content-Type", "application/json")
@@ -66,7 +82,11 @@ func Http_gateway(ingress, egress net.Conn, c *AITransaction) error {
 					if err != nil {
 						slog.Error("writing blocking request", "err", err)
 					}
-
+					if c.Request.Debug {
+						b, _ := httputil.DumpResponse(&r, true)
+						fmt.Println(string(b))
+					}
+					slog.Info("block", "dest", ingress.RemoteAddr().String())
 					continue
 
 				}
@@ -130,13 +150,6 @@ func Http_gateway(ingress, egress net.Conn, c *AITransaction) error {
 			req.ContentLength = int64(len(newBody))
 			req.Body = io.NopCloser(bytes.NewBuffer(newBody))
 
-			if err != nil {
-				slog.Error("data read", "err", err)
-				if err == io.EOF {
-					return
-				}
-				return
-			}
 			err = req.Write(egress)
 			if err != nil {
 				slog.Error("data write", "err", err)


### PR DESCRIPTION
- UI yaml
- Block gives a HTTP 1/1 response now
- direct connection to backends no longer needs a proxy for AI workloads. 